### PR TITLE
feat: change jwt layout

### DIFF
--- a/src/components/Debugger.css
+++ b/src/components/Debugger.css
@@ -92,7 +92,6 @@
 }
 
 .decode-header {
-  padding: 0.4rem 1rem;
   border-bottom: 1px solid #ccc;
   font-size: 0.9rem;
   display: flex;
@@ -100,6 +99,14 @@
   gap: 0.5rem;
   justify-content: flex-start;
   align-items: baseline;
+  display: flex;
+  justify-content: space-between;
+  box-sizing: border-box;
+}
+
+.payload-subhead {
+  flex: 1;
+  padding: 0.4rem 1rem;
 }
 
 .decode-item {
@@ -116,6 +123,10 @@
 
 .decode-border-top {
   border-top: 1px solid #ccc;
+}
+.decode-payload-layout {
+  display: flex;
+  justify-content: flex-end;
 }
 
 .json-editor {

--- a/src/components/Debugger.css
+++ b/src/components/Debugger.css
@@ -32,6 +32,15 @@
   align-items: center;
   position: relative;
 }
+.code-reverse-wrapper {
+  display: flex;
+  flex-direction: row-reverse;
+  gap: 2rem;
+  width: 100%;
+  justify-content: center;
+  align-items: center;
+  position: relative;
+}
 
 .code-item {
   width: calc(50% - 1rem);

--- a/src/components/Debugger.tsx
+++ b/src/components/Debugger.tsx
@@ -180,43 +180,6 @@ CodeMirror.defineMode("jwt", function () {
   };
 });
 
-const DebuggerContent = ({
-  token,
-  setToken,
-  header,
-  setHeader,
-  tab,
-  setTab,
-  tabValue,
-  tabHandler,
-  secret,
-  setSecret,
-  base64Checked,
-  setBase64Checked,
-}: any) => (
-  <>
-    <DebuggerContainer headerText="Encoded">
-      <JwtCode token={token} setToken={setToken} />
-    </DebuggerContainer>
-
-    <DebuggerContainer headerText="Decoded">
-      <div className="decode-area">
-        <JwtHeader header={header} setHeader={setHeader} />
-        <Tabs tab={tab} setTab={setTab} />
-        <JwtPayload payload={tabValue[tab]} setPayload={tabHandler[tab]} />
-        <JwtSigature
-          secret={secret}
-          setSecret={setSecret}
-          checked={base64Checked}
-          setChecked={setBase64Checked}
-        />
-      </div>
-    </DebuggerContainer>
-  </>
-);
-
-export default DebuggerContent;
-
 const Tab = ({ tabName, isActive, setTab, children }: TabProps) => (
   <span
     className={isActive ? "decode-tab-active" : "decode-tab"}
@@ -228,26 +191,30 @@ const Tab = ({ tabName, isActive, setTab, children }: TabProps) => (
 
 const Tabs = ({ tab, setTab }: any) => (
   <div className="decode-header decode-border-top">
-    <Tab
-      tabName="claim"
-      isActive={tab === "claim"}
-      setTab={() => setTab("discloseFrame")}
-    >
-      Claims
-    </Tab>
-    <Tab
-      tabName="discloseFrame"
-      isActive={tab === "discloseFrame"}
-      setTab={() => setTab("discolsures")}
-    >
-      DiscloseFrames
-    </Tab>
-    <Tab
-      tabName="discolsures"
-      isActive={tab === "discolsures"}
-      setTab={() => setTab("discolsures")}
-    >
-      Discolsure
-    </Tab>
+    <div className="payload-subhead">
+      <Tab
+        tabName="claim"
+        isActive={tab === "claim"}
+        setTab={() => setTab("claim")}
+      >
+        Claims
+      </Tab>
+    </div>
+    <div className="payload-subhead">
+      <Tab
+        tabName="discloseFrame"
+        isActive={tab === "discloseFrame"}
+        setTab={() => setTab("discloseFrame")}
+      >
+        DiscloseFrames
+      </Tab>
+      <Tab
+        tabName="discolsures"
+        isActive={tab === "discolsures"}
+        setTab={() => setTab("discolsures")}
+      >
+        Discolsures
+      </Tab>
+    </div>
   </div>
 );

--- a/src/components/Debugger.tsx
+++ b/src/components/Debugger.tsx
@@ -14,6 +14,7 @@ import {
 import "./Debugger.css";
 import Button from "./common/Button";
 import { DebuggerContainer } from "./DebuggerContainer";
+import { Equipments } from "./Equipments";
 
 export const Debugger = () => {
   useEffect(() => {
@@ -59,6 +60,22 @@ export const Debugger = () => {
   const [tab, setTab] = useState<"claim" | "discloseFrame" | "discolsures">(
     "claim"
   );
+  const [isEcode, setIsEncode] = useState(false);
+
+  const encodeClaim = () => {
+    encode();
+    setIsEncode(false);
+  };
+
+  const decodeJwt = () => {
+    decode();
+    setIsEncode(true);
+  };
+
+  const shareSdJwt = async () => {
+    const result = await copyCurrentURLToClipboard();
+    if (result) message.success("URL is copied to your clipboard", 2);
+  };
 
   const tabValue = {
     claim: claims,
@@ -92,10 +109,20 @@ export const Debugger = () => {
       <Warning />
       <SelectAlgorithm />
 
-      <div className="code-wrapper">
+      <div>
+        <Equipments
+          isEcode={isEcode}
+          encodeClaim={encodeClaim}
+          decodeJwt={decodeJwt}
+          shareSdJwt={shareSdJwt}
+        />
+      </div>
+
+      <div className={isEcode ? "code-wrapper" : "code-reverse-wrapper"}>
         <DebuggerContainer headerText="Encoded">
           <JwtCode token={token} setToken={setToken} />
         </DebuggerContainer>
+
         <DebuggerContainer headerText="Decoded">
           <div className="decode-area">
             <JwtHeader header={header} setHeader={setHeader} />
@@ -109,22 +136,6 @@ export const Debugger = () => {
             />
           </div>
         </DebuggerContainer>
-      </div>
-
-      <div className="verified-share-wrapper">
-        <Button onClick={() => encode()}>Encode SD JWT</Button>
-        <Button onClick={() => decode()}>Decode SD JWT</Button>
-        <Button onClick={() => verify()}>Verify Signature</Button>
-        <Button
-          onClick={async () => {
-            const result = await copyCurrentURLToClipboard();
-            if (result) message.success("URL is copied to your clipboard", 2);
-          }}
-          className="subdue"
-          style={{ background: "transparent" }}
-        >
-          Share SD JWT
-        </Button>
       </div>
     </div>
   );
@@ -168,6 +179,43 @@ CodeMirror.defineMode("jwt", function () {
     },
   };
 });
+
+const DebuggerContent = ({
+  token,
+  setToken,
+  header,
+  setHeader,
+  tab,
+  setTab,
+  tabValue,
+  tabHandler,
+  secret,
+  setSecret,
+  base64Checked,
+  setBase64Checked,
+}: any) => (
+  <>
+    <DebuggerContainer headerText="Encoded">
+      <JwtCode token={token} setToken={setToken} />
+    </DebuggerContainer>
+
+    <DebuggerContainer headerText="Decoded">
+      <div className="decode-area">
+        <JwtHeader header={header} setHeader={setHeader} />
+        <Tabs tab={tab} setTab={setTab} />
+        <JwtPayload payload={tabValue[tab]} setPayload={tabHandler[tab]} />
+        <JwtSigature
+          secret={secret}
+          setSecret={setSecret}
+          checked={base64Checked}
+          setChecked={setBase64Checked}
+        />
+      </div>
+    </DebuggerContainer>
+  </>
+);
+
+export default DebuggerContent;
 
 const Tab = ({ tabName, isActive, setTab, children }: TabProps) => (
   <span

--- a/src/components/Debugger.tsx
+++ b/src/components/Debugger.tsx
@@ -57,9 +57,8 @@ export const Debugger = () => {
     verify,
   } = DebugHook();
 
-  const [tab, setTab] = useState<"claim" | "discloseFrame" | "discolsures">(
-    "claim"
-  );
+  type TabType = "claim" | "discloseFrame" | "discolsures";
+  const [tab, setTab] = useState<TabType>("claim");
   const [isEcode, setIsEncode] = useState(false);
 
   const encodeClaim = () => {
@@ -126,7 +125,11 @@ export const Debugger = () => {
         <DebuggerContainer headerText="Decoded">
           <div className="decode-area">
             <JwtHeader header={header} setHeader={setHeader} />
-            <Tabs tab={tab} setTab={setTab} />
+            {isEcode ? (
+              <SingleTab tab={tab} setTab={setTab} />
+            ) : (
+              <MultiTab tab={tab} setTab={setTab} />
+            )}
             <JwtPayload payload={tabValue[tab]} setPayload={tabHandler[tab]} />
             <JwtSigature
               secret={secret}
@@ -144,7 +147,7 @@ export const Debugger = () => {
 interface TabProps {
   tabName: string;
   isActive: boolean;
-  setTab: any;
+  setTab: React.Dispatch<React.SetStateAction<string>>;
   children: ReactNode;
 }
 
@@ -180,41 +183,34 @@ CodeMirror.defineMode("jwt", function () {
   };
 });
 
-const Tab = ({ tabName, isActive, setTab, children }: TabProps) => (
-  <span
-    className={isActive ? "decode-tab-active" : "decode-tab"}
-    onClick={() => setTab(tabName)}
-  >
-    {children}
-  </span>
+const SingleTab = ({ tab, setTab }: any) => (
+  <div className="decode-header decode-border-top">
+    <span
+      className={tab === "discolsures" ? "decode-tab-active" : "decode-tab"}
+      onClick={() => setTab("discolsures")}
+    >
+      {"Discolsures"}
+    </span>
+  </div>
 );
 
-const Tabs = ({ tab, setTab }: any) => (
+const MultiTab = ({ tab, setTab }: any) => (
   <div className="decode-header decode-border-top">
     <div className="payload-subhead">
-      <Tab
-        tabName="claim"
-        isActive={tab === "claim"}
-        setTab={() => setTab("claim")}
+      <span
+        className={tab === "claim" ? "decode-tab-active" : "decode-tab"}
+        style={{ borderRight: "1px solid #ccc", paddingRight: "1.25rem" }}
+        onClick={() => setTab("claim")}
       >
-        Claims
-      </Tab>
-    </div>
-    <div className="payload-subhead">
-      <Tab
-        tabName="discloseFrame"
-        isActive={tab === "discloseFrame"}
-        setTab={() => setTab("discloseFrame")}
+        {"Claims"}
+      </span>
+      <span
+        className={tab === "discloseFrame" ? "decode-tab-active" : "decode-tab"}
+        onClick={() => setTab("discloseFrame")}
+        style={{ paddingLeft: "1.25rem" }}
       >
-        DiscloseFrames
-      </Tab>
-      <Tab
-        tabName="discolsures"
-        isActive={tab === "discolsures"}
-        setTab={() => setTab("discolsures")}
-      >
-        Discolsures
-      </Tab>
+        {"DiscloseFrames"}
+      </span>
     </div>
   </div>
 );

--- a/src/components/Debugger.tsx
+++ b/src/components/Debugger.tsx
@@ -59,16 +59,16 @@ export const Debugger = () => {
 
   type TabType = "claim" | "discloseFrame" | "discolsures";
   const [tab, setTab] = useState<TabType>("claim");
-  const [isEcode, setIsEncode] = useState(false);
+  const [isEcoded, setIsEncoded] = useState(false);
 
   const encodeClaim = () => {
     encode();
-    setIsEncode(false);
+    setIsEncoded(true);
   };
 
   const decodeJwt = () => {
     decode();
-    setIsEncode(true);
+    setIsEncoded(false);
   };
 
   const shareSdJwt = async () => {
@@ -110,14 +110,14 @@ export const Debugger = () => {
 
       <div>
         <Equipments
-          isEcode={isEcode}
+          isEcoded={isEcoded}
           encodeClaim={encodeClaim}
           decodeJwt={decodeJwt}
           shareSdJwt={shareSdJwt}
         />
       </div>
 
-      <div className={isEcode ? "code-wrapper" : "code-reverse-wrapper"}>
+      <div className={isEcoded ? "code-wrapper" : "code-reverse-wrapper"}>
         <DebuggerContainer headerText="Encoded">
           <JwtCode token={token} setToken={setToken} />
         </DebuggerContainer>
@@ -125,7 +125,7 @@ export const Debugger = () => {
         <DebuggerContainer headerText="Decoded">
           <div className="decode-area">
             <JwtHeader header={header} setHeader={setHeader} />
-            {isEcode ? (
+            {isEcoded ? (
               <SingleTab tab={tab} setTab={setTab} />
             ) : (
               <MultiTab tab={tab} setTab={setTab} />

--- a/src/components/Debugger.tsx
+++ b/src/components/Debugger.tsx
@@ -108,14 +108,12 @@ export const Debugger = () => {
       <Warning />
       <SelectAlgorithm />
 
-      <div>
-        <Equipments
-          isEcoded={isEcoded}
-          encodeClaim={encodeClaim}
-          decodeJwt={decodeJwt}
-          shareSdJwt={shareSdJwt}
-        />
-      </div>
+      <Equipments
+        isEcoded={isEcoded}
+        encodeClaim={encodeClaim}
+        decodeJwt={decodeJwt}
+        shareSdJwt={shareSdJwt}
+      />
 
       <div className={isEcoded ? "code-wrapper" : "code-reverse-wrapper"}>
         <DebuggerContainer headerText="Encoded">

--- a/src/components/Equipments.tsx
+++ b/src/components/Equipments.tsx
@@ -1,21 +1,21 @@
 import Button from "./common/Button";
 
 interface EquipmentsProps {
-  isEcode: boolean;
+  isEcoded: boolean;
   encodeClaim: () => void;
   decodeJwt: () => void;
   shareSdJwt: () => void;
 }
 export const Equipments = ({
-  isEcode,
+  isEcoded,
   encodeClaim,
   decodeJwt,
   shareSdJwt,
 }: EquipmentsProps) => {
   return (
     <div>
-      <Button onClick={isEcode ? () => encodeClaim() : () => decodeJwt()}>
-        {isEcode ? "Decode SD JWT" : "Encode SD JWT"}
+      <Button onClick={isEcoded ? () => decodeJwt() : () => encodeClaim()}>
+        {isEcoded ? "Decode SD JWT" : "Encode SD JWT"}
       </Button>
 
       <Button

--- a/src/components/Equipments.tsx
+++ b/src/components/Equipments.tsx
@@ -1,11 +1,17 @@
 import Button from "./common/Button";
 
+interface EquipmentsProps {
+  isEcode: boolean;
+  encodeClaim: () => void;
+  decodeJwt: () => void;
+  shareSdJwt: () => void;
+}
 export const Equipments = ({
   isEcode,
   encodeClaim,
   decodeJwt,
   shareSdJwt,
-}: any) => {
+}: EquipmentsProps) => {
   return (
     <div>
       <Button onClick={isEcode ? () => encodeClaim() : () => decodeJwt()}>

--- a/src/components/Equipments.tsx
+++ b/src/components/Equipments.tsx
@@ -1,0 +1,24 @@
+import Button from "./common/Button";
+
+export const Equipments = ({
+  isEcode,
+  encodeClaim,
+  decodeJwt,
+  shareSdJwt,
+}: any) => {
+  return (
+    <div>
+      <Button onClick={isEcode ? () => encodeClaim() : () => decodeJwt()}>
+        {isEcode ? "Decode SD JWT" : "Encode SD JWT"}
+      </Button>
+
+      <Button
+        onClick={shareSdJwt}
+        className="subdue"
+        style={{ background: "transparent" }}
+      >
+        Share SD JWT
+      </Button>
+    </div>
+  );
+};

--- a/src/components/decoded/JwtPayload.tsx
+++ b/src/components/decoded/JwtPayload.tsx
@@ -6,7 +6,7 @@ export const JwtPayload = ({
   setPayload,
 }: {
   payload: string;
-  setPayload: any;
+  setPayload: React.Dispatch<React.SetStateAction<string>>;
 }) => {
   return (
     <div style={decodeItem}>

--- a/src/components/decoded/JwtSigature.tsx
+++ b/src/components/decoded/JwtSigature.tsx
@@ -11,7 +11,7 @@ export const JwtSigature = ({
   secret: any;
   setSecret: any;
   checked: boolean;
-  setChecked: any;
+  setChecked: React.Dispatch<React.SetStateAction<boolean>>;
 }) => {
   const onChange = (e: CheckboxChangeEvent) => {
     console.log(`checked = ${e.target.checked}`);

--- a/src/hooks/debug.hook.ts
+++ b/src/hooks/debug.hook.ts
@@ -1,11 +1,11 @@
-import { useState } from 'react';
-import { bufferToBase64Url, decodeBase64URL } from '../utils';
-import { SDJwtInstance } from '@lukas.j.han/sd-jwt-core';
-import { Signer, Verifier } from '@lukas.j.han/sd-jwt-type';
-import { digest, generateSalt } from '@lukas.j.han/sd-jwt-browser-crypto';
-import { message } from 'antd';
+import { useState } from "react";
+import { bufferToBase64Url, decodeBase64URL } from "../utils";
+import { SDJwtInstance } from "@lukas.j.han/sd-jwt-core";
+import { Signer, Verifier } from "@lukas.j.han/sd-jwt-type";
+import { digest, generateSalt } from "@lukas.j.han/sd-jwt-browser-crypto";
+import { message } from "antd";
 
-const initialSecret = 'your-256-bit-secret';
+const initialSecret = "your-256-bit-secret";
 
 const getSigner = (secret: string): Signer => {
   return async (data: string) => {
@@ -14,17 +14,17 @@ const getSigner = (secret: string): Signer => {
     const messageData = encoder.encode(data);
 
     const cryptoKey = await window.crypto.subtle.importKey(
-      'raw',
+      "raw",
       keyData,
-      { name: 'HMAC', hash: 'SHA-256' },
+      { name: "HMAC", hash: "SHA-256" },
       false,
-      ['sign'],
+      ["sign"]
     );
 
     const signature = await window.crypto.subtle.sign(
-      'HMAC',
+      "HMAC",
       cryptoKey,
-      messageData,
+      messageData
     );
     return bufferToBase64Url(signature);
   };
@@ -37,23 +37,23 @@ const getVerifier = (secret: string): Verifier => {
     const messageData = encoder.encode(data);
     const signatureData = Uint8Array.from(
       decodeBase64URL(signature)
-        .split('')
-        .map((c) => c.charCodeAt(0)),
+        .split("")
+        .map((c) => c.charCodeAt(0))
     );
 
     const cryptoKey = await window.crypto.subtle.importKey(
-      'raw',
+      "raw",
       keyData,
-      { name: 'HMAC', hash: 'SHA-256' },
+      { name: "HMAC", hash: "SHA-256" },
       false,
-      ['verify'],
+      ["verify"]
     );
 
     return window.crypto.subtle.verify(
-      'HMAC',
+      "HMAC",
       cryptoKey,
       signatureData,
-      messageData,
+      messageData
     );
   };
 };
@@ -61,14 +61,14 @@ const getVerifier = (secret: string): Verifier => {
 const sdjwt = new SDJwtInstance({
   signer: getSigner(initialSecret),
   verifier: getVerifier(initialSecret),
-  signAlg: 'HS256',
+  signAlg: "HS256",
   hasher: digest,
-  hashAlg: 'SHA-256',
+  hashAlg: "SHA-256",
   saltGenerator: generateSalt,
 });
 
 const initialToken =
-  'eyJ0eXAiOiJzZC1qd3QiLCJhbGciOiJIUzI1NiJ9.eyJsYXN0bmFtZSI6IkRvZSIsInNzbiI6IjEyMy00NS02Nzg5IiwiX3NkIjpbImVfMnZHTkpGcXBBVHNxd21NcDVJWXQ0cHlSb25KQmVOV2pNN3BJdFJtMUkiLCJ4UnptQWlCYjV5Vk9jUHNDWUdwaEVCdjRCZWRtVkZpQlBnakROLWNjN1NRIl0sIl9zZF9hbGciOiJTSEEtMjU2In0.IgTBKAhwyT0qaopCQUC_-RYKC2uBknxEwucCWAgSBXM~WyI5NDUxZjMzN2E4ZTQ3NzU5IiwiZmlyc3RuYW1lIiwiSm9obiJd~WyI3NjQ1YjUwOTM1YjQ4ZmNjIiwiaWQiLCIxMjM0Il0~';
+  "eyJ0eXAiOiJzZC1qd3QiLCJhbGciOiJIUzI1NiJ9.eyJsYXN0bmFtZSI6IkRvZSIsInNzbiI6IjEyMy00NS02Nzg5IiwiX3NkIjpbImVfMnZHTkpGcXBBVHNxd21NcDVJWXQ0cHlSb25KQmVOV2pNN3BJdFJtMUkiLCJ4UnptQWlCYjV5Vk9jUHNDWUdwaEVCdjRCZWRtVkZpQlBnakROLWNjN1NRIl0sIl9zZF9hbGciOiJTSEEtMjU2In0.IgTBKAhwyT0qaopCQUC_-RYKC2uBknxEwucCWAgSBXM~WyI5NDUxZjMzN2E4ZTQ3NzU5IiwiZmlyc3RuYW1lIiwiSm9obiJd~WyI3NjQ1YjUwOTM1YjQ4ZmNjIiwiaWQiLCIxMjM0Il0~";
 
 export const DebugHook = () => {
   const [token, setToken] = useState(initialToken);
@@ -77,52 +77,52 @@ export const DebugHook = () => {
   const [discloseFrame, setDiscloseFrame] = useState(
     JSON.stringify(
       {
-        _sd: ['firstname', 'id'],
+        _sd: ["firstname", "id"],
       },
       null,
-      2,
-    ),
+      2
+    )
   );
   const [claims, setClaims] = useState(
     JSON.stringify(
       {
-        firstname: 'John',
-        lastname: 'Doe',
-        ssn: '123-45-6789',
-        id: '1234',
+        firstname: "John",
+        lastname: "Doe",
+        ssn: "123-45-6789",
+        id: "1234",
       },
       null,
-      2,
-    ),
+      2
+    )
   );
   const [discolsures, setDiscolsures] = useState(
     JSON.stringify(
       [
         {
-          salt: '9451f337a8e47759',
-          key: 'firstname',
-          value: 'John',
+          salt: "9451f337a8e47759",
+          key: "firstname",
+          value: "John",
         },
         {
-          salt: '7645b50935b48fcc',
-          key: 'id',
-          value: '1234',
+          salt: "7645b50935b48fcc",
+          key: "id",
+          value: "1234",
         },
       ],
       null,
-      2,
-    ),
+      2
+    )
   );
 
   const [header, setHeader] = useState(
     JSON.stringify(
       {
-        alg: 'HS256',
-        typ: 'sd+jwt',
+        alg: "HS256",
+        typ: "sd+jwt",
       },
       null,
-      2,
-    ),
+      2
+    )
   );
 
   const encode = async () => {
@@ -142,7 +142,7 @@ export const DebugHook = () => {
       setDiscolsures(JSON.stringify(sdJwtToken.disclosures, null, 2));
     } catch (e) {
       console.error(e);
-      message.error('Encode Failed', 2);
+      message.error("Encode Failed", 2);
     }
   };
 
@@ -156,10 +156,10 @@ export const DebugHook = () => {
       setHeader(header);
       setDiscolsures(disclosures);
       setClaims(JSON.stringify(claims, null, 2));
-      setDiscloseFrame('');
+      setDiscloseFrame("");
     } catch (e) {
       console.error(e);
-      message.error('Decode Failed', 2);
+      message.error("Decode Failed", 2);
     }
   };
 
@@ -171,13 +171,13 @@ export const DebugHook = () => {
       });
       const result = await sdjwt.validate(token);
       if (result) {
-        message.success('Verify Success', 2);
+        message.success("Verify Success", 2);
       } else {
-        message.error('Verify Failed', 2);
+        message.error("Verify Failed", 2);
       }
     } catch (e) {
       console.error(e);
-      message.error('Verify Failed', 2);
+      message.error("Verify Failed", 2);
     }
   };
 


### PR DESCRIPTION
## Description
* [x] Change by pressing the 
* [x] encode/decode toggle button
    * Previously, encode/decode were referenced to each other and changed automatically.
* [x] Removed encode and deode buttons as they became automatic
    * Control encode/decode with toggle, change automatically when decided with toggle
* [x] claim / discloseFrame Discolusure divided into two and changed layout to left and right
* [x] When encoding, only disclosure is exposed; when decoding, both discloseFrame and disclosure are exposed.
<!--
Please do not leave this blank
This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->

## What type of PR is this?

- [x] 🍕 Feature


## Related Tickets & Documents

<!--
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
