### PR TITLE
feat: restore copying in read only editor

### DIFF
--- a/src/components/decoded/JwtHeader.tsx
+++ b/src/components/decoded/JwtHeader.tsx
@@ -22,7 +22,7 @@ export const JwtHeader = ({
         <ControlledEditor
           value={header}
           options={{
-            readOnly: mode === 'encode' ? 'nocursor' : false,
+            readOnly: mode === 'encode' ? true : false,
             mode: 'javascript',
             lineWrapping: true,
           }}

--- a/src/components/decoded/JwtHeader.tsx
+++ b/src/components/decoded/JwtHeader.tsx
@@ -22,7 +22,7 @@ export const JwtHeader = ({
         <ControlledEditor
           value={header}
           options={{
-            readOnly: mode === 'encode' ? true : false,
+            readOnly: mode === 'encode',
             mode: 'javascript',
             lineWrapping: true,
           }}

--- a/src/components/decoded/JwtPayload.tsx
+++ b/src/components/decoded/JwtPayload.tsx
@@ -21,7 +21,7 @@ export const JwtPayload = ({
         value={payload}
         options={{
           mode: 'javascript',
-          readOnly: mode === 'encode' ? 'nocursor' : false,
+          readOnly: mode === 'encode' ? true : false,
           lineWrapping: true,
         }}
         onBeforeChange={(editor, data, value) => {

--- a/src/components/decoded/JwtPayload.tsx
+++ b/src/components/decoded/JwtPayload.tsx
@@ -21,7 +21,7 @@ export const JwtPayload = ({
         value={payload}
         options={{
           mode: 'javascript',
-          readOnly: mode === 'encode' ? true : false,
+          readOnly: mode === 'encode',
           lineWrapping: true,
         }}
         onBeforeChange={(editor, data, value) => {

--- a/src/components/encoded/JwtCode.tsx
+++ b/src/components/encoded/JwtCode.tsx
@@ -17,7 +17,7 @@ export const JwtCode = ({
         options={{
           mode: 'jwt',
           lineWrapping: true,
-          readOnly: mode === 'decode' ? true : false,
+          readOnly: mode === 'decode',
         }}
         onBeforeChange={(editor, data, value) => {
           updateURLWithQuery(value, mode);

--- a/src/components/encoded/JwtCode.tsx
+++ b/src/components/encoded/JwtCode.tsx
@@ -17,7 +17,7 @@ export const JwtCode = ({
         options={{
           mode: 'jwt',
           lineWrapping: true,
-          readOnly: mode === 'decode' ? 'nocursor' : false,
+          readOnly: mode === 'decode' ? true : false,
         }}
         onBeforeChange={(editor, data, value) => {
           updateURLWithQuery(value, mode);


### PR DESCRIPTION
## Description

<!--
Please do not leave this blank
This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->

## What type of PR is this?

- [x] 🍕 Feature

I restore the readonly configuration to true from 'nocursor'. Now we're good to copy :) 

## Related Tickets & Documents

<!--
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
