### PR TITLE
feat: set alg while decode to change key area to verify

### DIFF
--- a/src/hooks/debug.hook.ts
+++ b/src/hooks/debug.hook.ts
@@ -233,6 +233,12 @@ export const DebugHook = () => {
       setClaims(JSON.stringify(claims, null, 2));
       setDiscloseFrame('');
       setIsValid(true);
+      if (sdJwtToken.jwt?.header?.alg) {
+        const alg = sdJwtToken.jwt.header?.alg as string;
+        if (alg && ['HS256', 'ES256'].includes(alg)) {
+          setAlg(alg);
+        }
+      }
     } catch (e) {
       console.error(e);
       setHeader('');


### PR DESCRIPTION
## Description

<!--
Please do not leave this blank
This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->

## What type of PR is this?

- [x] 🐛 Bug Fix

When user input a token, it's decoded to objects. but alg is not set, so user can't verify with their public key

## Related Tickets & Documents

<!--
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
