### PR TITLE
Fix/b64 check

### DIFF
--- a/src/components/Debugger.tsx
+++ b/src/components/Debugger.tsx
@@ -8,6 +8,8 @@ import './Debugger.css';
 import { DebuggerContainer } from './DebuggerContainer';
 import { Equipments } from './Equipments';
 
+// Mode represents the left section
+// e.g. if mode is encode, then left section is `encoded`
 export type ModeType = 'encode' | 'decode';
 
 export const Debugger = () => {

--- a/src/components/Debugger.tsx
+++ b/src/components/Debugger.tsx
@@ -47,6 +47,7 @@ export const Debugger = () => {
     pubpriKey,
     setPubPriKey,
     setSecret,
+    setBase64Checked,
   } = DebugHook();
 
   const [mode, setMode] = useState<ModeType>('encode');
@@ -115,6 +116,7 @@ export const Debugger = () => {
               mode={mode}
               setPubPriKey={setPubPriKey}
               setSecret={setSecret}
+              setBase64Checked={setBase64Checked}
             />
           </div>
         </DebuggerContainer>

--- a/src/components/decoded/JwtSigature.tsx
+++ b/src/components/decoded/JwtSigature.tsx
@@ -14,6 +14,7 @@ export const JwtSigature = ({
   mode,
   setPubPriKey,
   setSecret,
+  setBase64Checked,
 }: {
   alg: string;
   secret: string;
@@ -23,9 +24,11 @@ export const JwtSigature = ({
   mode: string;
   setPubPriKey: (data: { pri: string; pub: string }) => void;
   setSecret: (data: string) => void;
+  setBase64Checked: (check: boolean) => void;
 }) => {
   const onChange = (e: CheckboxChangeEvent) => {
-    encode({ b64checked: e.target.checked });
+    if (mode === 'decode') encode({ b64checked: e.target.checked });
+    if (mode === 'encode') setBase64Checked(e.target.checked);
   };
   const field =
     alg === 'HS256' ? (


### PR DESCRIPTION
## Description

<!--
Please do not leave this blank
This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->

## What type of PR is this?

- [x] 🐛 Bug Fix

When encode mode, we should not update encoded token. but when I check the b64, It re-generate token.
I fixed with just set the b64check state when mode is encode

## Related Tickets & Documents

<!--
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
