### PR TITLE
fix: mode typo

### DIFF
--- a/src/components/Equipments.tsx
+++ b/src/components/Equipments.tsx
@@ -5,7 +5,7 @@ import { Radio, RadioChangeEvent } from 'antd';
 import { ModeType } from './Debugger';
 import { DECODED, ENCODED } from './Debugger';
 interface EquipmentsProps {
-  mode: string;
+  mode: ModeType;
   alg: string;
   setAlg: (value: string) => void;
   switchMode: (mode: ModeType) => void;

--- a/src/components/decoded/JwtHeader.tsx
+++ b/src/components/decoded/JwtHeader.tsx
@@ -1,6 +1,7 @@
 import { Controlled as ControlledEditor } from 'react-codemirror2';
 import { decodeItem, decodeHeader, decodeDescStyle } from '../common/style';
 import { UpdateEncode } from '../../hooks/debug.hook';
+import { ENCODED, ModeType } from '../Debugger';
 
 export const JwtHeader = ({
   header,
@@ -9,7 +10,7 @@ export const JwtHeader = ({
 }: {
   header: string;
   setHeader: (data: UpdateEncode) => Promise<void>;
-  mode: string;
+  mode: ModeType;
 }) => {
   return (
     <>
@@ -22,7 +23,7 @@ export const JwtHeader = ({
         <ControlledEditor
           value={header}
           options={{
-            readOnly: mode === 'encode',
+            readOnly: mode === ENCODED,
             mode: 'javascript',
             lineWrapping: true,
           }}

--- a/src/components/decoded/JwtPayload.tsx
+++ b/src/components/decoded/JwtPayload.tsx
@@ -1,11 +1,12 @@
 import { Controlled as ControlledEditor } from 'react-codemirror2';
 import { decodeItem } from '../common/style';
 import { UpdateEncode } from '../../hooks/debug.hook';
+import { ENCODED, ModeType } from '../Debugger';
 
 interface JwtPayloadType {
   payload: string;
   setPayload: (data: UpdateEncode) => Promise<void>;
-  mode: string;
+  mode: ModeType;
   type: 'claim' | 'disclosureFrame';
   className?: string;
 }
@@ -13,7 +14,7 @@ interface JwtPayloadType {
 export const JwtPayload = ({ payload, setPayload, mode, type, className }: JwtPayloadType) => {
   const editorOption = {
     mode: 'javascript',
-    readOnly: mode === 'encode',
+    readOnly: mode === ENCODED,
     lineWrapping: true,
   };
 

--- a/src/components/decoded/JwtSigature.tsx
+++ b/src/components/decoded/JwtSigature.tsx
@@ -5,7 +5,7 @@ import { decodeHeader, decodeHeaderTop } from '../common/style';
 import { UpdateEncode } from '../../hooks/debug.hook';
 import TextArea from 'antd/es/input/TextArea';
 import { CSSProperties } from 'react';
-import { ENCODED, DECODED } from '../Debugger';
+import { ENCODED, DECODED, ModeType } from '../Debugger';
 
 const HS256 = 'HS256';
 
@@ -15,7 +15,7 @@ interface JwtSigatureType {
   pubpriKey: { pri: string; pub: string };
   checked: boolean;
   encode: (data: UpdateEncode) => Promise<void>;
-  mode: string;
+  mode: ModeType;
   setPubPriKey: (data: { pri: string; pub: string }) => void;
   setSecret: (data: string) => void;
   setBase64Checked: (check: boolean) => void;
@@ -66,7 +66,7 @@ export const JwtSigature = ({
 };
 
 interface HS256Type {
-  mode: string;
+  mode: ModeType;
   encode: (data: UpdateEncode) => Promise<void>;
   setSecret: (data: string) => void;
   secret: string;
@@ -98,7 +98,7 @@ const HS256Algorithm = ({ mode, encode, setSecret, secret, checked, onHandlecChe
 
 interface ES2565Type {
   setPubPriKey: (data: { pri: string; pub: string }) => void;
-  mode: string;
+  mode: ModeType;
   encode: (data: UpdateEncode) => Promise<void>;
   pubpriKey: { pri: string; pub: string };
 }

--- a/src/components/encoded/JwtCode.tsx
+++ b/src/components/encoded/JwtCode.tsx
@@ -1,5 +1,6 @@
 import { Controlled as ControlledEditor } from 'react-codemirror2';
 import { updateURLWithQuery } from '../../utils';
+import { DECODED, ModeType } from '../Debugger';
 
 export const JwtCode = ({
   token,
@@ -8,7 +9,7 @@ export const JwtCode = ({
 }: {
   token: string;
   updateToken: (token: string) => void;
-  mode: string;
+  mode: ModeType;
 }) => {
   return (
     <div className="area-wrapper">
@@ -17,7 +18,7 @@ export const JwtCode = ({
         options={{
           mode: 'jwt',
           lineWrapping: true,
-          readOnly: mode === 'decode',
+          readOnly: mode === DECODED,
         }}
         onBeforeChange={(editor, data, value) => {
           updateURLWithQuery(value, mode);


### PR DESCRIPTION
## Description

<!--
Please do not leave this blank
This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->

## What type of PR is this?

- [x] 🐛 Bug Fix

After the #38, there is a typo bug of `mode`.
I fixed it and scan all files that use `mode`. 

## Related Tickets & Documents

<!--
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
