### PR TITLE
Revert "feat: Add Pageview Tracker (#46)"

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -17,16 +17,6 @@
       user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/
     -->
   <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
-  <!-- Google tag (gtag.js) -->
-  <script async src="https://www.googletagmanager.com/gtag/js?id=G-YSLD6T408C"></script>
-  <script>
-    window.dataLayer = window.dataLayer || [];
-    function gtag() { dataLayer.push(arguments); }
-    gtag('js', new Date());
-    gtag('config', 'G-YSLD6T408C', {
-      page_path: '/'
-    });
-  </script>
   <!--
       Notice the use of %PUBLIC_URL% in the tags above.
       It will be replaced with the URL of the `public` folder during the build.


### PR DESCRIPTION
This closes #51

GA uses cookies but currently we don't have cookie banner. So I decided to remove it for now.

